### PR TITLE
Add simple Todo web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Test Todo App
 
-This repository contains a simple Todo web application built with Python's built-in `http.server` module.
+This repository contains a simple Todo web application built with Python's
+built-in `http.server` module. The application script is `todo_app.py` and lives
+in the repository root, so after cloning make sure you are on the `main` branch
+or pull the latest changes to see it.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# test
-gpttest
+# Test Todo App
+
+This repository contains a simple Todo web application built with Python's built-in `http.server` module.
+
+## Usage
+
+1. Run the server:
+   ```bash
+   python3 todo_app.py
+   ```
+2. Open `http://localhost:8000/` in your browser.
+3. Add a task with `http://localhost:8000/add?task=My%20task`.
+4. View tasks at `http://localhost:8000/list`.

--- a/todo_app.py
+++ b/todo_app.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""
+Simple Todo App using Python's built-in http.server.
+
+Usage:
+    python3 todo_app.py
+Then open http://localhost:8000/ in your browser.
+"""
+
+import http.server
+import json
+from urllib.parse import parse_qs, urlparse
+
+TASKS = []
+
+class TodoHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        if parsed.path == '/':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/html')
+            self.end_headers()
+            self.wfile.write(
+                b"<h1>Todo App</h1><p>Add tasks with /add?task=Task.</p><p>List tasks with /list.</p>"
+            )
+        elif parsed.path == '/add':
+            qs = parse_qs(parsed.query)
+            task = qs.get('task', [''])[0]
+            if task:
+                TASKS.append(task)
+                self.send_response(200)
+                self.send_header('Content-Type', 'text/plain')
+                self.end_headers()
+                self.wfile.write(f"Added task: {task}".encode())
+            else:
+                self.send_response(400)
+                self.send_header('Content-Type', 'text/plain')
+                self.end_headers()
+                self.wfile.write(b'Missing task parameter.')
+        elif parsed.path == '/list':
+            self.send_response(200)
+            self.send_header('Content-Type', 'application/json')
+            self.end_headers()
+            self.wfile.write(json.dumps(TASKS).encode())
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+
+def run(port: int = 8000):
+    server_address = ('', port)
+    httpd = http.server.HTTPServer(server_address, TodoHandler)
+    print(f'Serving on http://localhost:{port}')
+    httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    run()


### PR DESCRIPTION
## Summary
- create `todo_app.py`, a simple HTTP server-based Todo application
- update README with running instructions

## Testing
- `python3 -u todo_app.py`

------
https://chatgpt.com/codex/tasks/task_e_686b5cec92c0832cbf5b2ee0a70824d0