### PR TITLE
Add real-time audio frequency visualizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# test
-gpttest
+# 音声周波数ビジュアライザー
+
+このリポジトリには、マイクから入力された音声をリアルタイムで周波数表示する `audio_visualizer.py` が含まれています。
+
+## 使い方
+
+1. 依存関係のインストール（Python3 が必要です）
+   ```bash
+   pip install sounddevice matplotlib numpy
+   ```
+2. スクリプトの実行
+   ```bash
+   python3 audio_visualizer.py
+   ```
+   実行すると新しいウィンドウが開き、リアルタイムで周波数スペクトルが表示されます。
+
+マイク入力が利用できない環境では動作しない場合があります。

--- a/audio_visualizer.py
+++ b/audio_visualizer.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""音声の周波数をリアルタイムでビジュアライズする簡単なスクリプト"""
+
+import queue
+import numpy as np
+import sounddevice as sd
+import matplotlib.pyplot as plt
+from matplotlib.animation import FuncAnimation
+
+SAMPLE_RATE = 44100  # サンプリング周波数
+BLOCK_SIZE = 1024
+
+q = queue.Queue()
+
+
+def audio_callback(indata, frames, time, status):
+    """オーディオ入力からデータをキューへ入れるコールバック"""
+    if status:
+        print(status)
+    q.put(indata.copy())
+
+
+def update(frame):
+    """アニメーション更新用の関数"""
+    while not q.empty():
+        data = q.get()
+        spectrum = np.abs(np.fft.rfft(data[:, 0]))
+        line.set_ydata(spectrum)
+    return line,
+
+
+fig, ax = plt.subplots()
+
+freqs = np.fft.rfftfreq(BLOCK_SIZE, 1 / SAMPLE_RATE)
+line, = ax.plot(freqs, np.zeros_like(freqs))
+ax.set_xlabel('Frequency [Hz]')
+ax.set_ylabel('Amplitude')
+ax.set_ylim(0, 50)
+ax.set_xlim(0, SAMPLE_RATE / 2)
+
+
+if __name__ == '__main__':
+    stream = sd.InputStream(
+        callback=audio_callback,
+        channels=1,
+        samplerate=SAMPLE_RATE,
+        blocksize=BLOCK_SIZE,
+    )
+    with stream:
+        ani = FuncAnimation(fig, update, interval=30, blit=True)
+        plt.show()


### PR DESCRIPTION
## Summary
- add `audio_visualizer.py` for real-time microphone spectrum visualization
- update README (Japanese) with instructions on installing dependencies and running

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c7851155c832ca2deaf26567bd8a6